### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/bin/crontab/gen-crons.py
+++ b/bin/crontab/gen-crons.py
@@ -24,12 +24,12 @@ def main():
     if not opts.webapp:
         parser.error('-w must be defined')
 
-    ctx = {'django': 'cd %s; %s manage.py' % (opts.webapp, opts.python)}
-    ctx['cron'] = '%s cron' % ctx['django']
+    ctx = {'django': 'cd {0!s}; {1!s} manage.py'.format(opts.webapp, opts.python)}
+    ctx['cron'] = '{0!s} cron'.format(ctx['django'])
 
     if opts.user:
         for k, v in ctx.iteritems():
-            ctx[k] = '%s %s' % (opts.user, v)
+            ctx[k] = '{0!s} {1!s}'.format(opts.user, v)
 
     # Needs to stay below the opts.user injection.
     ctx['python'] = opts.python

--- a/bin/update/deploy.py
+++ b/bin/update/deploy.py
@@ -20,7 +20,7 @@ def update_code(ctx, tag):
     """Update the code to a specific git reference (tag/sha/etc)."""
     with ctx.lcd(settings.SRC_DIR):
         ctx.local('git fetch')
-        ctx.local('git checkout -f %s' % tag)
+        ctx.local('git checkout -f {0!s}'.format(tag))
         ctx.local('git submodule sync')
         ctx.local('git submodule update --init --recursive')
 
@@ -67,8 +67,7 @@ def install_cron(ctx):
     with ctx.lcd(settings.SRC_DIR):
         ctx.local('python2.6 ./bin/crontab/gen-crons.py -w %s -u apache > '
                   '/etc/cron.d/.%' % (settings.WWW_DIR, settings.CRON_NAME))
-        ctx.local('mv /etc/cron.d/.%s /etc/cron.d/%s' %
-                  (settings.CRON_NAME,  settings.CRON_NAME))
+        ctx.local('mv /etc/cron.d/.{0!s} /etc/cron.d/{1!s}'.format(settings.CRON_NAME, settings.CRON_NAME))
 
 
 @task
@@ -81,14 +80,14 @@ def checkin_changes(ctx):
 def deploy_app(ctx):
     """Call the remote update script to push changes to webheads."""
     ctx.remote(settings.REMOTE_UPDATE_SCRIPT)
-    ctx.remote('/bin/touch %s' % settings.REMOTE_WSGI)
+    ctx.remote('/bin/touch {0!s}'.format(settings.REMOTE_WSGI))
 
 
 @hostgroups(settings.CELERY_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
 def update_celery(ctx):
     """Update and restart Celery."""
     ctx.remote(settings.REMOTE_UPDATE_SCRIPT)
-    ctx.remote('/sbin/service %s restart' % settings.CELERY_SERVICE)
+    ctx.remote('/sbin/service {0!s} restart'.format(settings.CELERY_SERVICE))
 
 
 @task

--- a/bin/update_site.py
+++ b/bin/update_site.py
@@ -94,16 +94,16 @@ def update_site(env, debug):
     for cmd, cmd_args in commands:
         if CHDIR == cmd:
             if debug:
-                sys.stdout.write("cd %s\n" % cmd_args)
+                sys.stdout.write("cd {0!s}\n".format(cmd_args))
             os.chdir(cmd_args)
         elif EXEC == cmd:
             if debug:
-                sys.stdout.write("%s\n" % cmd_args)
+                sys.stdout.write("{0!s}\n".format(cmd_args))
             if not 0 == os.system(cmd_args):
                 error_updating = True
                 break
         else:
-            raise Exception("Unknown type of command %s" % cmd)
+            raise Exception("Unknown type of command {0!s}".format(cmd))
 
     if error_updating:
         sys.stderr.write("There was an error while updating. Please try again "
@@ -120,8 +120,8 @@ def main():
         """.rstrip())
 
     options = OptionParser(usage=usage)
-    e_help = "Type of environment. One of (%s) Example: update_site.py \
-        -e stage" % '|'.join(ENV_BRANCH.keys())
+    e_help = "Type of environment. One of ({0!s}) Example: update_site.py \
+        -e stage".format('|'.join(ENV_BRANCH.keys()))
     options.add_option("-e", "--environment", help=e_help)
     options.add_option("-v", "--verbose",
                        help="Echo actions before taking them.",

--- a/witness/admin.py
+++ b/witness/admin.py
@@ -31,7 +31,7 @@ class DocumentAdmin(admin.ModelAdmin):
         ''' Add a new version for a document '''
         try:
             document = queryset.get()
-            return redirect( "%s?document=%s" % (
+            return redirect( "{0!s}?document={1!s}".format(
                     urlresolvers.reverse('admin:witness_documentversion_add'),
                     document.id)
                    )
@@ -79,8 +79,8 @@ class DocumentVersionAdmin(admin.ModelAdmin):
         queryset.update(is_retired=True)
         self.message_user(
                 request,
-                "Successfully retired %s document version(s)" %
-                    queryset.count()
+                "Successfully retired {0!s} document version(s)".format(
+                    queryset.count())
             )
     def document_title(self, obj):
         return str(obj.document.title)

--- a/witness/models.py
+++ b/witness/models.py
@@ -48,7 +48,7 @@ class DocumentVersion(models.Model):
     require_address = models.BooleanField(default=False)
 
     def __unicode__(self):
-        return "%s - %s" % (self.document, self.title)
+        return "{0!s} - {1!s}".format(self.document, self.title)
 
     def get_absolute_url(self):
         return reverse(
@@ -88,7 +88,7 @@ class Decision(models.Model):
                 default=None)
 
     def __unicode__(self):
-        return "%s %s" % (self.document_version.title, self.action_text)
+        return "{0!s} {1!s}".format(self.document_version.title, self.action_text)
 
     class Meta:
         verbose_name = "3. Decision"

--- a/witness/settings/__init__.py
+++ b/witness/settings/__init__.py
@@ -6,5 +6,5 @@ from .base import *
 try:
     from .local import *
 except ImportError, exc:
-    exc.args = tuple(['%s (did you rename settings/local.py-dist?)' % exc.args[0]])
+    exc.args = tuple(['{0!s} (did you rename settings/local.py-dist?)'.format(exc.args[0])])
     raise exc

--- a/witness/settings/base.py
+++ b/witness/settings/base.py
@@ -32,7 +32,7 @@ MINIFY_BUNDLES = {
 }
 
 # Defines the views served for root URLs.
-ROOT_URLCONF = '%s.urls' % PROJECT_MODULE
+ROOT_URLCONF = '{0!s}.urls'.format(PROJECT_MODULE)
 
 INSTALLED_APPS = list(INSTALLED_APPS) + [
     # Deployment.
@@ -42,7 +42,7 @@ INSTALLED_APPS = list(INSTALLED_APPS) + [
     # Additional Mozilla shared apps.
     'django_browserid',
     # Application base, containing global templates.
-    '%s.base' % PROJECT_MODULE,
+    '{0!s}.base'.format(PROJECT_MODULE),
     # Main application.
     'witness',
     # Admin interface
@@ -65,9 +65,9 @@ JINGO_EXCLUDE_APPS = [
 # Tells the extract script what files to look for L10n in and what function
 # handles the extraction. The Tower library expects this.
 DOMAIN_METHODS['messages'] = [
-    ('%s/**.py' % PROJECT_MODULE,
+    ('{0!s}/**.py'.format(PROJECT_MODULE),
         'tower.management.commands.extract.extract_tower_python'),
-    ('%s/**/templates/**.html' % PROJECT_MODULE,
+    ('{0!s}/**/templates/**.html'.format(PROJECT_MODULE),
         'tower.management.commands.extract.extract_tower_template'),
     ('templates/**.html',
         'tower.management.commands.extract.extract_tower_template'),

--- a/witness/tests.py
+++ b/witness/tests.py
@@ -22,8 +22,8 @@ class WitnessTestHelper(object):
     def create_document(self, **kwargs):
         self.slug_counter = getattr(self, 'slug_counter', 0) + 1
         defaults = {
-            'title': 'Test Document %d' % self.slug_counter,
-            'slug': 'doc-%d' % self.slug_counter,
+            'title': 'Test Document {0:d}'.format(self.slug_counter),
+            'slug': 'doc-{0:d}'.format(self.slug_counter),
         }
         defaults.update(kwargs)
         return Document.objects.create(**defaults)
@@ -31,8 +31,8 @@ class WitnessTestHelper(object):
     def create_documentversion(self, **kwargs):
         self.slug_counter = getattr(self, 'slug_counter', 0) + 1
         defaults = {
-            'number': 'v-%d' % self.slug_counter,
-            'title': 'Test Version %d' % self.slug_counter,
+            'number': 'v-{0:d}'.format(self.slug_counter),
+            'title': 'Test Version {0:d}'.format(self.slug_counter),
             'text': 'Lorem ipsum dolor.',
             'yes_action_text': 'Yes',
             'no_action_text': 'No',
@@ -46,7 +46,7 @@ class WitnessTestHelper(object):
     def create_decision(self, **kwargs):
         self.slug_counter = getattr(self, 'slug_counter', 0) + 1
         defaults = {
-            'email': 'test-%d@example.com' % self.slug_counter,
+            'email': 'test-{0:d}@example.com'.format(self.slug_counter),
             'full_name': 'John Doe',
             'ip_address': '111.222.333.444',
             'action_text': 'Yes',
@@ -55,7 +55,7 @@ class WitnessTestHelper(object):
         if 'document_version' not in kwargs:
             defaults['document_version'] = self.create_documentversion()
         if 'user' not in kwargs:
-            defaults['user'] = User.objects.create(username='test-%d' % self.slug_counter)
+            defaults['user'] = User.objects.create(username='test-{0:d}'.format(self.slug_counter))
         defaults.update(kwargs)
         return Decision.objects.create(**defaults)
 
@@ -65,7 +65,7 @@ class WitnessTestHelper(object):
         old_prefix = get_url_prefix()
         old_locale = get_language()
         rf = test_utils.RequestFactory()
-        set_url_prefix(Prefixer(rf.get('/%s/' % (locale,))))
+        set_url_prefix(Prefixer(rf.get('/{0!s}/'.format(locale))))
         activate(locale)
         yield
         set_url_prefix(old_prefix)

--- a/witness/urls.py
+++ b/witness/urls.py
@@ -39,6 +39,6 @@ if settings.DEBUG:
     # Remove leading and trailing slashes so the regex matches.
     media_url = settings.MEDIA_URL.lstrip('/').rstrip('/')
     urlpatterns += patterns('',
-        (r'^%s/(?P<path>.*)$' % media_url, 'django.views.static.serve',
+        (r'^{0!s}/(?P<path>.*)$'.format(media_url), 'django.views.static.serve',
          {'document_root': settings.MEDIA_ROOT}),
     )

--- a/witness/views.py
+++ b/witness/views.py
@@ -95,9 +95,9 @@ def document_detail(request, document_slug, version_number):
                                 else document_version.no_action_text
                 decision.save()
 
-                message = "Here's the document: %s " % request.build_absolute_uri(
-                        document_version.get_absolute_url())
-                send_mail(subject="You signed %s" % (decision),
+                message = "Here's the document: {0!s} ".format(request.build_absolute_uri(
+                        document_version.get_absolute_url()))
+                send_mail(subject="You signed {0!s}".format((decision)),
                           message=message,
                           from_email='admin@example.com',
                           recipient_list=(user.email,),)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:witness?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:witness?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
